### PR TITLE
Issue #2: Update the demo sandboxes to run on PHP 8.1

### DIFF
--- a/.tugboat/config.yml
+++ b/.tugboat/config.yml
@@ -1,6 +1,6 @@
 services:
   php:
-    image: tugboatqa/php:7.4-apache
+    image: tugboatqa/php:8.1-apache
     default: true
     alias_type: domain
     aliases:


### PR DESCRIPTION
Fixes https://github.com/backdrop-ops/tugboat-demos/issues/2